### PR TITLE
WP 6.2 : Replace deprecated `Requests` and use WpOrg class on WP_Http_Remote_Post_TestCase

### DIFF
--- a/includes/testcase-http-remote-post.php
+++ b/includes/testcase-http-remote-post.php
@@ -1,5 +1,7 @@
 <?php
 
+use WpOrg\Requests\Requests;
+
 /**
  * Test remote requests without actually sending them.
  *


### PR DESCRIPTION
`Requests` class going to be deprecated in the new WP Version 6.2, to avoid errors we have to use `WpOrg\Requests\Requests` instead.

![image](https://user-images.githubusercontent.com/5392202/224142750-bc93ad06-52d3-4ed0-a09d-70360f18cf1f.png)
