### PR TITLE
Add WP_CLI::debug()

### DIFF
--- a/includes/mock-wp-cli.php
+++ b/includes/mock-wp-cli.php
@@ -98,6 +98,18 @@ namespace {
 
 
 		/**
+		 * Store messages in this class.
+		 *
+		 * @param string|WP_Error|Exception|Throwable $message Message to output.
+		 * @param string|bool $group Organize debug message to a specific group.
+		 *
+		 * @return void
+		 */
+		public static function debug( $message, bool|string $group = false ): void {
+			self::$case->debug[] = [ $message, $group ];
+		}
+
+		/**
 		 * Currently a noop to prevent fatal errors during testing.
 		 *
 		 * @param string $command

--- a/includes/testcase-wp-cli.php
+++ b/includes/testcase-wp-cli.php
@@ -29,6 +29,13 @@ abstract class WP_CLI_UnitTestCase extends WP_UnitTestCase {
 	 */
 	public $error = [];
 
+	/**
+	 * Hold debug messages added during this test.
+	 *
+	 * @var array<array{string|WP_Error|Exception|Throwable, bool|string}>
+	 */
+	public $debug = [];
+
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();


### PR DESCRIPTION
Adds method for `debug()` in the style of other loggers in mock.

Types intended to match source: https://github.com/wp-cli/wp-cli/blob/c0513d0195584132d9bbd4265092fd323ee6060b/php/class-wp-cli.php#L803-L850